### PR TITLE
Type predicate inference and infer keyword

### DIFF
--- a/src/infer/infer.ts
+++ b/src/infer/infer.ts
@@ -1,0 +1,28 @@
+// `infer` keyword
+
+// The `infer` keyword is used inside conditional types to extract and infer specific types
+// from complex structures. It allows TypeScript to determine a type automatically.
+
+// Why is it useful?
+
+// 1. Extracting the return type of a function
+
+// Without `infer`, we have to manually write the return type.
+const func = (x: number): string => x.toString();
+type ReturnTypeManual = string;
+
+// With `infer`, TypeScript extracts the return type automatically.
+// - `T extends (...args: any[]) => infer R` means:
+// - If `T` is a function, infer (guess) its return type `R`, otherwise return `never`.
+type GetReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
+type ReturnTypeOfFunc = GetReturnType<typeof func>; // TypeScript infers: string
+
+// 2. Extracting the type inside a Promise
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
+type Result = UnwrapPromise<Promise<number>>; // TypeScript infers: number
+
+// 3. Extracting the element type from an array
+
+type Flatten<T> = T extends Array<infer Item> ? Item : T;
+type Str = Flatten<string[]>; // TypeScript infers: string

--- a/src/infer/infer.ts
+++ b/src/infer/infer.ts
@@ -3,10 +3,6 @@
 // The `infer` keyword is used inside conditional types to extract and infer specific types
 // from complex structures. It allows TypeScript to determine a type automatically.
 
-// Why is it useful?
-
-// 1. Extracting the return type of a function
-
 // Without `infer`, we have to manually write the return type.
 const func = (x: number): string => x.toString();
 type ReturnTypeManual = string;
@@ -17,12 +13,18 @@ type ReturnTypeManual = string;
 type GetReturnType<T> = T extends (...args: any[]) => infer R ? R : never;
 type ReturnTypeOfFunc = GetReturnType<typeof func>; // TypeScript infers: string
 
-// 2. Extracting the type inside a Promise
+// TypeScript's `Awaited<T>` Utility Type
 
+// - `T extends Promise<infer U>` extracts the resolved type of a single-level Promise.
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 type Result = UnwrapPromise<Promise<number>>; // TypeScript infers: number
 
-// 3. Extracting the element type from an array
+// The utility type `Awaited<T>` was introduced in TypeScript 4.5 and recursively unwraps promises
+// until it finds the final resolved type. 
 
-type Flatten<T> = T extends Array<infer Item> ? Item : T;
-type Str = Flatten<string[]>; // TypeScript infers: string
+type A = Awaited<Promise<string>>; // TypeScript infers: string
+type B = Awaited<Promise<Promise<number>>>; // TypeScript infers: number
+type C = Awaited<boolean | Promise<number>>; // TypeScript infers: number | boolean
+
+// `Awaited<T>` removes all nested Promises, making it more powerful for deep async operations,
+// whereas the `UnwrapPromise<T>` only extracts one layer of a `Promise<T>.

--- a/src/infer/src/final.ts
+++ b/src/infer/src/final.ts
@@ -1,0 +1,30 @@
+// Solution Exercise 1
+
+// Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
+
+type ExtractResponse<T> = T extends (...args: any[]) => Promise<infer R>
+  ? R
+  : never;
+
+// Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>`
+// and use `ExtractResponse` to infer its return type.
+
+const fetchData = (): Promise<{ data: string; success: boolean }> => {
+  return Promise.resolve({ data: 'Hello', success: true });
+};
+
+type ResponseType = ExtractResponse<typeof fetchData>;
+
+// Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
+
+type ExtractArrayItem<T> = T extends Array<infer U> ? U : never;
+
+// Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
+
+const movies = ['Inception', 'Interstellar', 'Dune'];
+
+type MovieType = ExtractArrayItem<typeof movies>;
+
+// Log the inferred type of the first movie and the return type of `fetchData()`.
+console.log(typeof movies[0]); // Expected output: "string"
+console.log(typeof fetchData()); // Expected output: "object" (Promise)

--- a/src/infer/src/final.ts
+++ b/src/infer/src/final.ts
@@ -1,30 +1,53 @@
 // Solution Exercise 1
 
-// Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
+// Create a type `MovieInfo<T>` that extracts the genre from strings like:
+// `'Movie: Inception (Genre: Sci-Fi)'` and `'Movie: Titanic (Genre: Romance)'`.
 
-type ExtractResponse<T> = T extends (...args: any[]) => Promise<infer R>
-  ? R
+type MovieInfo<T> = T extends `Movie: ${string} (Genre: ${infer Genre})`
+  ? Genre
   : never;
 
-// Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>`
-// and use `ExtractResponse` to infer its return type.
+// Use `MovieInfo` to infer the genre for these two examples.
 
-const fetchData = (): Promise<{ data: string; success: boolean }> => {
-  return Promise.resolve({ data: 'Hello', success: true });
-};
+type Genre1 = MovieInfo<'Movie: Inception (Genre: Sci-Fi)'>; // TypeScript infers: 'Sci-Fi'
+type Genre2 = MovieInfo<'Movie: Titanic (Genre: Romance)'>; // TypeScript infers: 'Romance'
 
-type ResponseType = ExtractResponse<typeof fetchData>;
+// Solution Exercise 2
 
-// Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
+// Given the `movieRoutes` object, use `infer` to extract:
 
-type ExtractArrayItem<T> = T extends Array<infer U> ? U : never;
+const movieRoutes = {
+  'watched:get': '/watched/get',
+  'watched:rate': '/watched/rate/:movieId',
+  'favorites:get': '/favorites/get',
+  'favorites:add': '/favorites/add/:movieId',
+  'wishlist:get': '/wishlist/get',
+  'wishlist:add': '/wishlist/add/:movieId',
+} as const;
 
-// Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
+// The list of movie categories (like `watched`, `favorites`, or `wishlist`) into a type called `MovieCategories`.
 
-const movies = ['Inception', 'Interstellar', 'Dune'];
+type MovieCategories =
+  keyof typeof movieRoutes extends `${infer Category}:${string}`
+    ? Category
+    : never;
 
-type MovieType = ExtractArrayItem<typeof movies>;
+// The list of actions for `watched` routes (like `get` or `rate`) into a type called `WatchedActions`.
 
-// Log the inferred type of the first movie and the return type of `fetchData()`.
-console.log(typeof movies[0]); // Expected output: "string"
-console.log(typeof fetchData()); // Expected output: "object" (Promise)
+type WatchedActions = keyof typeof movieRoutes extends `${infer Action}`
+  ? Action extends `watched:${infer Action}`
+    ? Action
+    : never
+  : never;
+
+// The list of actions for `wishlist` routes (like `add`) into a type called `WishlistActions`.
+
+type WishlistActions = keyof typeof movieRoutes extends `${infer Action}`
+  ? Action extends `wishlist:${infer Action}`
+    ? Action
+    : never
+  : never;
+
+const category: MovieCategories = 'watched'; // Valid
+const watchedAction: WatchedActions = 'rate'; // Valid
+const wishlistAction: WishlistActions = 'add'; // Valid

--- a/src/infer/src/initial.ts
+++ b/src/infer/src/initial.ts
@@ -1,16 +1,27 @@
 // Exercise 1
 
-// Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
+// Create a type `MovieInfo<T>` that extracts the genre from strings like:
+// `'Movie: Inception (Genre: Sci-Fi)'` and `'Movie: Titanic (Genre: Romance)'`.
 
-type ExtractResponse<T> = T extends (...args: any[]) => Promise<infer R>
-  ? R
+type MovieInfo<T> = T extends `Movie: ${string} (Genre: ${infer Genre})`
+  ? Genre
   : never;
 
-// Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>`
-// and use `ExtractResponse` to infer its return type.
+// Use `MovieInfo` to infer the genre for these two examples.
 
-// Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
+// Exercise 2
 
-// Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
+// Given the `movieRoutes` object, use `infer` to extract:
 
-// Log the inferred type of the first movie and the return type of `fetchData()`.
+const movieRoutes = {
+  'watched:get': '/watched/get',
+  'watched:rate': '/watched/rate/:movieId',
+  'favorites:get': '/favorites/get',
+  'favorites:add': '/favorites/add/:movieId',
+  'wishlist:get': '/wishlist/get',
+  'wishlist:add': '/wishlist/add/:movieId',
+} as const;
+
+// The list of movie categories (like `watched`, `favorites`, or `wishlist`) into a type called `MovieCategories`.
+// The list of actions for `watched` routes (like `get` or `rate`) into a type called `WatchedActions`.
+// The list of actions for `wishlist` routes (like `add`) into a type called `WishlistActions`.

--- a/src/infer/src/initial.ts
+++ b/src/infer/src/initial.ts
@@ -1,0 +1,16 @@
+// Exercise 1
+
+// Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
+
+type ExtractResponse<T> = T extends (...args: any[]) => Promise<infer R>
+  ? R
+  : never;
+
+// Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>`
+// and use `ExtractResponse` to infer its return type.
+
+// Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
+
+// Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
+
+// Log the inferred type of the first movie and the return type of `fetchData()`.

--- a/src/infer/src/readme.md
+++ b/src/infer/src/readme.md
@@ -1,9 +1,14 @@
 Exercise 1
 
-In this exercise, you will use the `infer` keyword to extract and infer specific types dynamically.
+In this exercise, you will use the `infer` keyword to extract types dynamically from string templates.
 
-- Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
-- Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>` and use `ExtractResponse` to infer its return type.
-- Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
-- Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
-- Log the inferred type of the first movie and the return type of `fetchData()`.
+- Create a type `MovieInfo<T>` that extracts the genre from strings like:
+  `'Movie: Inception (Genre: Sci-Fi)'` and `'Movie: Titanic (Genre: Romance)'`.
+  Use `MovieInfo` to infer the genre for these two examples.
+
+Exercise 2
+
+Given the `movieRoutes` object, use `infer` to extract:
+- The list of movie categories (like `watched`, `favorites`, or `wishlist`) into a type called `MovieCategories`.
+- The list of actions for `watched` routes (like `get` or `rate`) into a type called `WatchedActions`.
+- The list of actions for `wishlist` routes (like `add`) into a type called `WishlistActions`.

--- a/src/infer/src/readme.md
+++ b/src/infer/src/readme.md
@@ -1,0 +1,9 @@
+Exercise 1
+
+In this exercise, you will use the `infer` keyword to extract and infer specific types dynamically.
+
+- Create a type alias `ExtractResponse<T>` that extracts the return type of a function using `infer`.
+- Define a function `fetchData` that returns a `Promise<{ data: string; success: boolean }>` and use `ExtractResponse` to infer its return type.
+- Create a type alias `ExtractArrayItem<T>` that extracts the element type from an array using `infer`.
+- Use `ExtractArrayItem` to extract the type of elements from a `movies` array.
+- Log the inferred type of the first movie and the return type of `fetchData()`.

--- a/src/type-predicate-inference/src/final.ts
+++ b/src/type-predicate-inference/src/final.ts
@@ -1,0 +1,29 @@
+// Exercise 1
+
+// Define a `Person` type.
+type Person = {
+  id: string;
+  name: string;
+};
+
+// Define an array that contains a mix of values.
+const onlyPersonArray = ['a', 'b', 'c', 1, { id: '1', name: 'Peter' }, null];
+
+// Write a type guard function called `isPerson`:
+// - It should check whether a given value matches the `Person` type.
+// - The function must return `true` if the value is a valid `Person` object.
+
+const isPerson = (item: unknown): item is Person => {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'id' in item &&
+    'name' in item &&
+    typeof (item as any).id === 'string' &&
+    typeof (item as any).name === 'string'
+  );
+};
+
+// Use this type guard function with the `filter()` method
+// to extract only `Person` objects from the `onlyPersonArray`.
+const onlyPersons = onlyPersonArray.filter(isPerson); //Person[]

--- a/src/type-predicate-inference/src/initial.ts
+++ b/src/type-predicate-inference/src/initial.ts
@@ -1,0 +1,18 @@
+// Exercise 1
+
+// Define a `Person` type.
+type Person = {
+  id: string;
+  name: string;
+};
+
+// Define an array that contains a mix of values.
+const onlyPersonArray = ['a', 'b', 'c', 1, { id: '1', name: 'Peter' }, null];
+
+// Write a type guard function called `isPerson`:
+// - It should check whether a given value matches the `Person` type.
+// - The function must return `true` if the value is a valid `Person` object.
+
+// Use this type guard function with the `filter()` method to extract only `Person` objects from the `onlyPersonArray`.
+
+// Log the filtered array to verify the output.

--- a/src/type-predicate-inference/src/readme.md
+++ b/src/type-predicate-inference/src/readme.md
@@ -1,0 +1,28 @@
+Exercise 1
+
+In this exercise, you will learn to use TypeScript type guard functions to filter specific objects from a mixed array.
+
+Given the following:
+
+type Person = {
+  id: string;
+  name: string;
+};
+
+const onlyPersonArray = ['a', 'b', 'c', 1, { id: '1', name: 'Peter' }, null];
+
+1. Write a type guard function called `isPerson`:
+  - It should check whether a given value matches the `Person` type.
+  - The function must return `true` if the value is a valid `Person` object.
+
+2. Use this type guard function with the `filter()` method to extract only `Person` objects from the `onlyPersonArray`.
+
+3. Log the filtered array to verify the output.
+
+Hints:
+  - A valid `Person` object must:
+  - Be of type `object`.
+  - Contain the properties `id` and `name`.
+  - Have `id` and `name` as strings.
+  - Use `typeof` and `in` operators to validate object properties.
+  - Don’t forget to check for `null` values.

--- a/src/type-predicate-inference/type-predicate-inference.ts
+++ b/src/type-predicate-inference/type-predicate-inference.ts
@@ -17,3 +17,36 @@ const person: User | Guest = { id: 1, name: 'John' };
 if (isUser(person)) {
   console.log(person.name); // TypeScript treats `person` as a `User` inside this block
 }
+
+// TypeScript 5.5 introduced automatic type inference in certain scenarios,
+// making it easier to write clean and intuitive type-safe code.
+
+// Example 1: Inferring types with simple checks
+function isString(value: unknown) {
+  return typeof value === 'string';
+}
+
+const text: string | number = "test"
+if (isString(text)) {
+  console.log(text.toUpperCase()); // TypeScript infers `text` as a `string`
+}
+
+// Example 2: TypeScript can infer types correctly when using specific checks like `filter`
+
+const array = ['a', 'b', 'c', null];
+
+// TypeScript infers onlyTextArray as `string[]`
+const onlyTextArray = array.filter(
+  (item): item is string => typeof item === 'string',
+);
+
+// works as well
+const onlyTextArray2 = array.filter((item) => {
+  return item !== null;
+}); // string[]
+
+// doesn't work: using truthiness checks
+const onlyTextArray3 = array.filter((item) => !!item); // (string | null)[]
+
+// doesn't work: using the Boolean constructor
+const onlyTextArray4 = array.filter(Boolean); // (string | null)[]

--- a/src/type-predicate-inference/type-predicate-inference.ts
+++ b/src/type-predicate-inference/type-predicate-inference.ts
@@ -1,0 +1,19 @@
+// Type Predicate Inference
+
+// Type Predicate Inference allows TypeScript to determine a more specific type
+// inside a conditional block using custom type guard functions.
+
+type User = { id: number; name: string };
+type Guest = { isGuest: true };
+
+// Due to the type predicate `person is User`,
+// if this function returns `true`, it means that `person` is a `User`.
+const isUser = (person: User | Guest): person is User => {
+  return 'id' in person;
+};
+
+const person: User | Guest = { id: 1, name: 'John' };
+
+if (isUser(person)) {
+  console.log(person.name); // TypeScript treats `person` as a `User` inside this block
+}


### PR DESCRIPTION
Implemented explanations and exercises for:
- `Type Predicate Inference` to cover type narrowing with type guards.
- `infer` keyword to cover inferring types from functions and promises.