### PR TITLE
use type alias for all utility types

### DIFF
--- a/src/utility-types/omit.ts
+++ b/src/utility-types/omit.ts
@@ -8,12 +8,12 @@
 
 // Syntax: Omit<Type, Keys>
 
-interface Person {
+type Person = {
   name: string;
   age: number;
   address: string;
   email: string;
-}
+};
 
 type PersonWithoutAddress = Omit<Person, 'address'>;
 

--- a/src/utility-types/record.ts
+++ b/src/utility-types/record.ts
@@ -8,14 +8,14 @@
 
 type MovieTitle = 'Inception' | 'Titanic' | 'Interstellar';
 
-interface IMovieInfo {
+type MovieInfo = {
   genre: string;
   duration: number;
   releaseDate: Date;
-}
+};
 
 // Creating a Record type for a collection of movies with their titles as keys
-const movies: Record<MovieTitle, IMovieInfo> = {
+const movies: Record<MovieTitle, MovieInfo> = {
   Inception: {
     genre: 'Science Fiction',
     duration: 148,

--- a/src/utility-types/required.ts
+++ b/src/utility-types/required.ts
@@ -6,14 +6,14 @@
 
 // Syntax: Required<Type>
 
-interface ICity {
+type City = {
   name: string;
   country: string;
   population: number;
   hasMetro?: boolean;
-}
+};
 
-type CompleteCityInfo = Required<ICity>;
+type CompleteCityInfo = Required<City>;
 
 const city: CompleteCityInfo = {
   name: 'Tokyo',

--- a/src/utility-types/src/final.ts
+++ b/src/utility-types/src/final.ts
@@ -1,15 +1,15 @@
 // TypeScript utility types exercise solution.
 
 // Task 1: Partial
-interface IBankAccount {
+type BankAccount = {
   id: string;
   fullName: string;
   balance: number;
   isActive: boolean;
   creationDate?: Date;
-}
+};
 
-type PartialBankAccount = Partial<IBankAccount>;
+type PartialBankAccount = Partial<BankAccount>;
 
 const bankAccount: PartialBankAccount = {
   id: 'acc123',
@@ -18,7 +18,7 @@ const bankAccount: PartialBankAccount = {
 };
 
 // Task 2: Pick
-type CustomerId = Pick<IBankAccount, 'id' | 'fullName'>;
+type CustomerId = Pick<BankAccount, 'id' | 'fullName'>;
 
 const customer: CustomerId = {
   id: 'acc234',
@@ -26,7 +26,7 @@ const customer: CustomerId = {
 };
 
 // Task 3: Readonly
-type ReadonlyBankAccount = Readonly<IBankAccount>;
+type ReadonlyBankAccount = Readonly<BankAccount>;
 
 const readonlyBankAccount: ReadonlyBankAccount = {
   id: 'acc345',
@@ -39,7 +39,7 @@ const readonlyBankAccount: ReadonlyBankAccount = {
 // readonlyBankAccount.balance = 8000; // Error: Cannot assign to 'balance' because it is a read-only property
 
 // Task 4: Record
-type BankAccountRecord = Record<string, IBankAccount>;
+type BankAccountRecord = Record<string, BankAccount>;
 
 const bankAccountsList: BankAccountRecord = {
   account1: {
@@ -59,7 +59,7 @@ const bankAccountsList: BankAccountRecord = {
 };
 
 // Task 5: Required
-type FullBankAccountProfile = Required<IBankAccount>;
+type FullBankAccountProfile = Required<BankAccount>;
 
 const completeBankAccount: FullBankAccountProfile = {
   id: 'acc789',

--- a/src/utility-types/src/initial.ts
+++ b/src/utility-types/src/initial.ts
@@ -1,8 +1,8 @@
 // Task 1: Partial
-interface IBankAccount {
+type IBankAccount = {
   id: string;
   fullName: string;
   balance: number;
   isActive: boolean;
   creationDate?: Date;
-}
+};

--- a/src/utility-types/src/readme.md
+++ b/src/utility-types/src/readme.md
@@ -1,5 +1,5 @@
 Task 1: Partial
-Create an interface named 'IBankAccount' with 'id' (string), 'fullName' (string), 'balance' (number), and 'isActive' (boolean) properties.
+Create type named 'BankAccount' with 'id' (string), 'fullName' (string), 'balance' (number), and 'isActive' (boolean) properties.
 
 Add an optional property named 'creationDate' of type 'Date'.
 
@@ -9,13 +9,13 @@ Create an object named 'bankAccount' using the 'PartialBankAccount' type and ass
 
 Task 2: Pick
 
-Using the 'IBankAccount' interface, create a new type 'CustomerId' that picks only the 'id' and 'fullName' properties.
+Using the 'BankAccount' type, create a new type 'CustomerId' that picks only the 'id' and 'fullName' properties.
 
 Create an object named 'customer' using the 'CustomerId' type with 'id' and 'fullName' properties.
 
 Task 3: Readonly
 
-Make the 'IBankAccount' properties immutable using 'Readonly' to create a new type 'ReadonlyBankAccount'.
+Make the 'BankAccount' properties immutable using 'Readonly' to create a new type 'ReadonlyBankAccount'.
 
 Create an object named 'readonlyBankAccount' using the 'ReadonlyBankAccount' type.
 
@@ -23,13 +23,13 @@ Attempt to modify one of its properties to see the error and then comment it out
 
 Task 4: Record
 
-Create a 'Record' type 'BankAccountRecord' that maps string keys to 'IBankAccount' objects.
+Create a 'Record' type 'BankAccountRecord' that maps string keys to 'BankAccount' objects.
 
 Create an object named 'bankAccountsList' using the 'BankAccountRecord' type, including at least two bank accounts.
 
 Task 5: Required
 
-Make the optional properties of 'IBankAccount' required using 'Required' to create a new type 'FullBankAccountProfile'.
+Make the optional properties of 'BankAccount' required using 'Required' to create a new type 'FullBankAccountProfile'.
 
 Create an object named 'completeBankAccount' using the 'FullBankAccountProfile' type, ensuring all properties are included.
 


### PR DESCRIPTION
This PR includes changes for:

- convert all `utility-type` lessons and exercises to use type alias instead of interface